### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ matrix:
   include:
   - php: 5.3
     dist: precise
+  - php: 5.4
+  - php: 5.5
   - php: 5.6
   - php: 7.0
   - php: 7.1
+  - php: 7.2
   - php: nightly
 
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
   "homepage": "https://github.com/crazyfactory/php-curl",
   "license": "proprietary",
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3.0",
+    "ext-curl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
   },
   "autoload": {
     "psr-4": {
@@ -20,6 +21,6 @@
     }
   },
   "scripts": {
-    "test": "phpunit -c phpunit.xml"
+    "test": "phpunit"
   }
 }


### PR DESCRIPTION
# Changed log
- Remove the `-c phpunit.xml` because the `phpunit.xml` is in the repository root path. And the `phpunit` reads the `phpunit.xml` is root path by default.
- Add more tests.
- Using the class-based PHPUnit namespace to be compatible with the latest PHPUnit versions.
- Set the different PHPUnit versions to support the different PHP versions.